### PR TITLE
Electron 9 に備えて設定を変更

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -29,6 +29,9 @@ const createWindow = () => {
  */
 app.whenReady().then(createWindow);
 
+// Electron 9 への破壊的アップデートに備える。
+app.allowRendererProcessReuse = true;
+
 // 全てのウィンドウが閉じられた時に終了します。
 app.on(
     "window-all-closed",


### PR DESCRIPTION
## 起動時にでる警告に対応
Electron 9 からデフォルト値が変更される `app.allowRendererProcessReuse` を指定しました。

詳細については [こちら](https://github.com/electron/electron/issues/18397)