### PR TITLE
#22 対応で文字列を選択不可にする

### DIFF
--- a/src/renderer/components/Footer.jsx
+++ b/src/renderer/components/Footer.jsx
@@ -14,7 +14,7 @@ export default function Footer () {
         <footer className="w-full h-6 bg-gray-800">
             <p
                 className="
-                    text-xs text-gray-300 text-right
+                    text-xs text-gray-300 text-right select-none
                     leading-6 w-40 font-medium
                 "
             >

--- a/src/renderer/components/Tab.jsx
+++ b/src/renderer/components/Tab.jsx
@@ -8,7 +8,7 @@ export default function Tabs () {
     return (
         <div className="bg-gray-900 h-8 w-40 flex flex-row items-center">
             <h2 className="
-                text-xs text-gray-300
+                text-xs text-gray-300 select-none
                 my-1 ml-2 leading-6
                 w-32 h-6
                 "


### PR DESCRIPTION
#22 に対応して、タブとフッターの文字列を選択不可にしました。
選択不可には Tailwind CSS の `select-none` を使用しています。