### PR TITLE
フルスクリーン時にタイトルバーを消す

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,5 +23,6 @@ module.exports = {
         "react"
     ],
     "rules": {
+        "react/no-set-state": "off"
     }
 };

--- a/src/renderer/App.jsx
+++ b/src/renderer/App.jsx
@@ -1,14 +1,66 @@
 import {Footer, Main, TitleBar} from "./components/index";
-import React from "react";
+import React, {Component} from "react";
+import {remote} from "electron";
 
-export default function App () {
+export default class App extends Component {
 
-    return (
-        <div className="flex flex-col h-screen">
-            <TitleBar />
-            <Main />
-            <Footer />
-        </div>
-    );
+    constructor (props) {
+
+        super(props);
+        this.state = {
+
+            "isFullScreen": false
+
+        };
+
+        const currentWindow = remote.getCurrentWindow();
+
+        currentWindow.on(
+            "enter-full-screen",
+            () => {
+
+                this.setState({"isFullScreen": true});
+
+            }
+        );
+
+        currentWindow.on(
+            "leave-full-screen",
+            () => {
+
+                this.setState({"isFullScreen": false});
+
+            }
+        );
+
+    }
+
+    shouldComponentUpdate (nextProps, nextState) {
+
+        const {isFullScreen} = this.state;
+
+        if (isFullScreen !== nextState.isFullScreen) {
+
+            return true;
+
+        }
+
+        return false;
+
+    }
+
+    render () {
+
+        const {isFullScreen} = this.state;
+
+        return (
+            <div className="flex flex-col h-screen">
+                {!isFullScreen && <TitleBar />}
+                <Main />
+                <Footer />
+            </div>
+        );
+
+    }
 
 }


### PR DESCRIPTION
## ウインドウ／フルスクリーンでタイトルバーの表示切り替え
ウインドウモードではタイトルバーを表示し、フルスクリーン時にはタイトルバーを非表示とします。

この変更に伴い ESLint で `react/no-set-state` を全体で無視する設定を追加しました。
これは `state` への直接代入と `setState()` の両方を ESLint で禁止されるため、代入の手段がなくなるためです。
今回は[公式で推奨される](https://ja.reactjs.org/docs/state-and-lifecycle.html#do-not-modify-state-directly) `setState()` を使用する設定にしています。