### PR TITLE
文字を選択している際, 選択文字数をフッターに表示

### DIFF
--- a/src/renderer/components/EditArea.jsx
+++ b/src/renderer/components/EditArea.jsx
@@ -1,38 +1,58 @@
-/* eslint-disable react/jsx-no-bind */
 import "ace-builds/src-noconflict/ace";
 import "ace-builds/src-noconflict/mode-c_cpp";
 import "./theme-xenon";
+import React, {useCallback} from "react";
 import AceEditor from "react-ace";
-import React from "react";
 import {setCharCount} from "../reducks/charCount/actions";
 import {useDispatch} from "react-redux";
+
+const myRef = React.createRef();
+
+// eslint-disable-next-line one-var
+const getAllLength = () => {
+
+        const text = myRef.current.editor.getValue();
+        return text.length;
+
+    },
+    getSelectedLength = (select) => {
+
+        const empty = select.isEmpty();
+        let SelectedLength = 0;
+        if (!empty) {
+
+            const text = myRef.current.editor.getSelectedText();
+            SelectedLength = text.length;
+
+        } else if (empty) {
+
+            SelectedLength = getAllLength();
+
+        }
+        return SelectedLength;
+
+    };
 
 export default function EditArea () {
 
     const dispatch = useDispatch(),
-        myRef = React.createRef(),
-        onChange = () => {
+        updateChar = (length) => {
 
-            const text = myRef.current.editor.getValue();
-            dispatch(setCharCount(text.length));
-
-        },
-        onSelectionChange = (select) => {
-
-            const empty = select.isEmpty();
-            if (!empty) {
-
-                const selectedText = myRef.current.editor.getSelectedText();
-                dispatch(setCharCount(selectedText.length));
-
-            } else if (empty) {
-
-                onChange();
-
-            }
+            dispatch(setCharCount(length));
 
         };
 
+    // eslint-disable-next-line one-var
+    const onChange = useCallback(() => {
+
+            updateChar(getAllLength());
+
+        }),
+        onSelectionChange = useCallback((select) => {
+
+            updateChar(getSelectedLength(select));
+
+        });
     return (
         <div className="bg-gray-900 flex-auto">
             <AceEditor
@@ -56,5 +76,3 @@ export default function EditArea () {
     );
 
 }
-
-/* eslint-disable */

--- a/src/renderer/components/theme-xenon.js
+++ b/src/renderer/components/theme-xenon.js
@@ -37,7 +37,7 @@ ace.define("ace/theme/xenon",["require","exports","module","ace/lib/dom"], funct
         color: #FFFFFF\
     }\
     .ace-xenon .ace_marker-layer .ace_selection {\
-        background: #718096\
+        background: rgba(74, 85, 104, 0.8)\
     }\
     .ace-xenon.ace_multiselect .ace_selection.ace_start {\
         box-shadow: 0 0 3px 0px #272822;\
@@ -53,7 +53,7 @@ ace.define("ace/theme/xenon",["require","exports","module","ace/lib/dom"], funct
         background: #202020\
     }\
     .ace-xenon .ace_gutter-active-line {\
-        background-color: #2D3748;\
+        background-color: rgba(74, 85, 104, 0.8);\
     }\
     .ace-xenon .ace_marker-layer .ace_selected-word {\
         border: 1px solid #49483E\


### PR DESCRIPTION
今までEditAreaに書かれている文字数をフッターに表示していましたが, 
文字選択している際は全文字数ではなく, 選択文字数をフッターに表示する機能を追加しました. 

加えて, 選択しているときの範囲色を#718096に変更しました. 