### PR TITLE
スクロール機能の追加

### DIFF
--- a/src/renderer/components/Main.jsx
+++ b/src/renderer/components/Main.jsx
@@ -29,7 +29,7 @@ export default function Main() {
   };
 
   return (
-    <div className="flex flex-auto flex-col">
+    <div className="flex flex-auto flex-col overflow-scroll">
       <Tabs documents={documents} />
       {/* documentsに含まれているdocumentを全てレンダリング */}
       {documents.map((document) => {

--- a/src/renderer/components/Main.jsx
+++ b/src/renderer/components/Main.jsx
@@ -29,7 +29,7 @@ export default function Main() {
   };
 
   return (
-    <div className="flex flex-auto flex-col overflow-scroll">
+    <div className="flex flex-auto flex-col overflow-x-scroll">
       <Tabs documents={documents} />
       {/* documentsに含まれているdocumentを全てレンダリング */}
       {documents.map((document) => {

--- a/src/renderer/components/Tabs.jsx
+++ b/src/renderer/components/Tabs.jsx
@@ -22,7 +22,7 @@ export default function Tabs(props) {
   };
 
   return (
-    <div className="h-10 flex items-end overflow-scroll">
+    <div className="h-10 flex items-end overflow-scroll scrollbar-hiddon">
       {documents.map((document) => {
         return (
           <Tab

--- a/src/renderer/components/Tabs.jsx
+++ b/src/renderer/components/Tabs.jsx
@@ -22,7 +22,7 @@ export default function Tabs(props) {
   };
 
   return (
-    <div className="h-10 flex items-end">
+    <div className="h-10 flex items-end overflow-scroll">
       {documents.map((document) => {
         return (
           <Tab

--- a/src/renderer/components/Tabs.jsx
+++ b/src/renderer/components/Tabs.jsx
@@ -22,7 +22,7 @@ export default function Tabs(props) {
   };
 
   return (
-    <div className="h-10 flex items-end overflow-scroll scrollbar-hiddon">
+    <div className="h-10 flex items-end overflow-x-scroll scrollbar-hiddon">
       {documents.map((document) => {
         return (
           <Tab

--- a/src/style.css
+++ b/src/style.css
@@ -5,3 +5,7 @@
 header {
     -webkit-app-region: drag;
 }
+
+.scrollbar-hiddon::-webkit-scrollbar {
+    display: none;
+}


### PR DESCRIPTION
タブが複数ある場合のスクロール機能を実装しました. 

## 仕様
- 画面幅に余裕がある際はタブ幅はデフォルトの大きさ
- 余裕がない場合はファイル名の余白の部分を削り, タブを増やす
- 余白を削っても幅に余裕がない場合はスクロールができるようになる

以前この実装についていろいろ考えていましたが, 2箇所にoverflow-scrollを加えることで実装できました. 