### PR TITLE
ファイル名より言語を判断し, シンタックスハイライトをつける機能を実装

### DIFF
--- a/src/renderer/components/EditArea.jsx
+++ b/src/renderer/components/EditArea.jsx
@@ -1,13 +1,5 @@
-/* eslint-disable import/first */
-import 'ace-builds';
-// import 'ace-builds/webpack-resolver';
-// import 'ace-builds/src-noconflict/worker-json';
-// import ace from 'ace-builds/src-noconflict/ace';
-import 'ace-builds/src-noconflict/mode-javascript';
-
-// eslint-disable-next-line import/order
-const ace = require('ace-builds/src-noconflict/ace');
-
+import ace from 'ace-builds/src-noconflict/ace';
+import 'ace-builds/src-noconflict/ext-modelist';
 import './theme-xenon';
 import React, { useState } from 'react';
 import AceEditor from 'react-ace';
@@ -19,34 +11,30 @@ import {
   setActiveDocumentId,
 } from '../reducks/editor/actions';
 
-// import 'ace-builds/src-noconflict/ext-modelist';
+const fileNameToFileType = (fileName) => {
+  const modelist = ace.require('ace/ext/modelist');
+  const { mode } = modelist.getModeForPath(fileName);
+  const fileType = mode.split('/').pop();
 
-// const fileNameToFileType = (fileName) => {
-//   const modelist = ace.require('ace/ext/modelist');
-
-//   const { mode } = modelist.getModeForPath(fileName);
-//   const fileType = mode.split('/').pop();
-
-//   if (fileType == null) {
-//     return '';
-//   }
-//   try {
-/* eslint-disable import/no-dynamic-require */
-/* eslint-disable global-require */
-// require(`ace-builds/src-noconflict/mode-${fileType}`);
-//   } catch (e) {
-//     console.log(`error new mode(${fileType}): ${e}`);
-//   }
-//   return fileType;
-// };
+  try {
+    /* 対象のファイルタイプのみ読み込む */
+    /* eslint-disable import/no-dynamic-require */
+    /* eslint-disable global-require */
+    require(`ace-builds/src-noconflict/mode-${fileType}`);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(`error new mode(${fileType}): ${e}`);
+  }
+  return fileType;
+};
 
 const EditArea = React.memo((props) => {
   const [editorInstance, setEditorInstance] = useState('');
 
-  const { initialText, documentId } = props;
+  const { fileName, initialText, documentId } = props;
 
-  // const fileType = fileNameToFileType('blahblah/weee/some.js');
-  // console.log(fileType);
+  /* ファイル名からファイルタイプを設定 */
+  const fileType = fileNameToFileType(fileName);
 
   const dispatch = useDispatch();
   const onChange = () => {
@@ -61,7 +49,7 @@ const EditArea = React.memo((props) => {
   const onSelectionChange = () => {
     dispatch(setSelectedText(editorInstance, documentId));
   };
-  // console.log('fileType=', fileType)
+
   return (
     <div className="bg-gray-900 flex-auto">
       <AceEditor
@@ -71,8 +59,7 @@ const EditArea = React.memo((props) => {
         fontSize="16px"
         height="100%"
         highlightActiveLine={false}
-        // mode={fileType}
-        mode="javascript"
+        mode={fileType}
         name="UNIQUE_ID_OF_DIV"
         onChange={onChange}
         onLoad={onLoad}
@@ -90,6 +77,7 @@ const EditArea = React.memo((props) => {
 EditArea.propTypes = {
   initialText: PropTypes.string.isRequired,
   documentId: PropTypes.string.isRequired,
+  fileName: PropTypes.string.isRequired,
 };
 
 export default EditArea;

--- a/src/renderer/components/EditArea.jsx
+++ b/src/renderer/components/EditArea.jsx
@@ -1,5 +1,13 @@
-import 'ace-builds/src-noconflict/ace';
-import 'ace-builds/src-noconflict/mode-c_cpp';
+/* eslint-disable import/first */
+import 'ace-builds';
+// import 'ace-builds/webpack-resolver';
+// import 'ace-builds/src-noconflict/worker-json';
+// import ace from 'ace-builds/src-noconflict/ace';
+import 'ace-builds/src-noconflict/mode-javascript';
+
+// eslint-disable-next-line import/order
+const ace = require('ace-builds/src-noconflict/ace');
+
 import './theme-xenon';
 import React, { useState } from 'react';
 import AceEditor from 'react-ace';
@@ -11,11 +19,34 @@ import {
   setActiveDocumentId,
 } from '../reducks/editor/actions';
 
+// import 'ace-builds/src-noconflict/ext-modelist';
+
+// const fileNameToFileType = (fileName) => {
+//   const modelist = ace.require('ace/ext/modelist');
+
+//   const { mode } = modelist.getModeForPath(fileName);
+//   const fileType = mode.split('/').pop();
+
+//   if (fileType == null) {
+//     return '';
+//   }
+//   try {
+/* eslint-disable import/no-dynamic-require */
+/* eslint-disable global-require */
+// require(`ace-builds/src-noconflict/mode-${fileType}`);
+//   } catch (e) {
+//     console.log(`error new mode(${fileType}): ${e}`);
+//   }
+//   return fileType;
+// };
+
 const EditArea = React.memo((props) => {
   const [editorInstance, setEditorInstance] = useState('');
 
-  const { initialText } = props;
-  const { documentId } = props;
+  const { initialText, documentId } = props;
+
+  // const fileType = fileNameToFileType('blahblah/weee/some.js');
+  // console.log(fileType);
 
   const dispatch = useDispatch();
   const onChange = () => {
@@ -30,16 +61,18 @@ const EditArea = React.memo((props) => {
   const onSelectionChange = () => {
     dispatch(setSelectedText(editorInstance, documentId));
   };
-
+  // console.log('fileType=', fileType)
   return (
     <div className="bg-gray-900 flex-auto">
       <AceEditor
         value={initialText}
         editorProps={{ $blockScrolling: 'true' }}
+        setOptions={{ useWorker: false }}
         fontSize="16px"
         height="100%"
         highlightActiveLine={false}
-        mode="c_cpp"
+        // mode={fileType}
+        mode="javascript"
         name="UNIQUE_ID_OF_DIV"
         onChange={onChange}
         onLoad={onLoad}

--- a/src/renderer/components/EditArea.jsx
+++ b/src/renderer/components/EditArea.jsx
@@ -12,8 +12,8 @@ import {
 } from '../reducks/editor/actions';
 
 const fileNameToFileType = (fileName) => {
-  const modelist = ace.require('ace/ext/modelist');
-  const { mode } = modelist.getModeForPath(fileName);
+  const modeList = ace.require('ace/ext/modelist');
+  const { mode } = modeList.getModeForPath(fileName);
   const fileType = mode.split('/').pop();
 
   try {

--- a/src/renderer/components/Main.jsx
+++ b/src/renderer/components/Main.jsx
@@ -41,6 +41,7 @@ export default function Main() {
             key={document.documentId}
           >
             <EditArea
+              fileName={document.fileName}
               initialText={document.fileText}
               documentId={document.documentId}
             />

--- a/src/renderer/components/Main.jsx
+++ b/src/renderer/components/Main.jsx
@@ -14,7 +14,6 @@ export default function Main() {
   const activeDocumentId = getActiveDocumentId(editorState);
   const documents = getDocuments(editorState);
 
-  /* これでできたけど根本的な理由は不明, あとで調べる */
   useEffect(() => {
     if (documents.length === 0) {
       dispatch(setNewDocument());


### PR DESCRIPTION
ファイル名をもとにgetModeForPathというace-editor既存関数を使い, 
言語を判断しています.
その後, その言語のシンタックスハイライトを読み込んでいます. 