### PR TITLE
スクロールバーを表示状態に戻す

### DIFF
--- a/src/renderer/components/Body.jsx
+++ b/src/renderer/components/Body.jsx
@@ -15,7 +15,7 @@ export default function Body() {
   }
 
   return (
-    <div className="flex flex-auto overflow-y-scroll scrollbar-hiddon">
+    <div className="flex flex-auto overflow-y-scroll">
       <ResizePanel direction="e" handleClass="hidden" style={panelStyle}>
         <SideBar />
       </ResizePanel>

--- a/src/renderer/components/FileSelector.jsx
+++ b/src/renderer/components/FileSelector.jsx
@@ -9,7 +9,7 @@ export default function FileSelector() {
   const documents = getDocuments(editorState);
 
   return (
-    <div className="flex flex-auto flex-col overflow-y-scroll scrollbar-hiddon">
+    <div className="flex flex-auto flex-col overflow-y-scroll">
       {documents.map((document) => {
         return (
           <FileBlock

--- a/src/renderer/components/Main.jsx
+++ b/src/renderer/components/Main.jsx
@@ -28,7 +28,7 @@ export default function Main() {
   };
 
   return (
-    <div className="flex flex-auto flex-col overflow-x-scroll scrollbar-hiddon">
+    <div className="flex flex-auto flex-col overflow-x-scroll">
       <Tabs documents={documents} />
       {/* documentsに含まれているdocumentを全てレンダリング */}
       {documents.map((document) => {

--- a/src/renderer/components/theme-xenon.js
+++ b/src/renderer/components/theme-xenon.js
@@ -7,9 +7,6 @@ ace.define(
     exports.cssClass = 'ace-xenon';
     exports.cssText =
       ' \
-    .ace-xenon .ace_scrollbar{\
-        display: none;\
-    }\
     .ace-xenon .ace_cursor{\
         position: relative !important;\
         right: 2px;\


### PR DESCRIPTION
やはり、OS の設定を優先するべきで、スクロールバーが表示されないのは、スクロールの可否・量がわからなくなってしまうので、元に戻す。